### PR TITLE
feat(home): show recent GitHub repos

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -5,6 +5,7 @@ import Intro from "@/components/Home/Intro";
 import Resume from "@/components/Home/Resume";
 import Posts from "@/components/Home/Posts";
 import Projects from "@/components/Home/Projects";
+import GitHubRepos from "@/components/Home/GitHubRepos";
 import NowPlaying from "@/components/Home/NowPlaying";
 import NowReading from "@/components/Home/NowReading";
 import { Main } from "@/components/Layouts";
@@ -173,7 +174,7 @@ export const Route = createFileRoute("/")({
 });
 
 function HomeComponent() {
-  const { introHtml, initialData } = Route.useLoaderData();
+  const { githubRepos, introHtml, initialData } = Route.useLoaderData();
 
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
@@ -201,6 +202,7 @@ function HomeComponent() {
       <Intro introHtml={introHtml} />
       <Resume />
       <Posts posts={posts} />
+      <GitHubRepos repos={githubRepos} />
       <Projects />
       <NowPlaying
         spotifyStatus={liveData?.musicStatus}


### PR DESCRIPTION
## Summary
- import and render `GitHubRepos` on the homepage
- pass loader-provided `githubRepos` into the component
- place the section between Posts and Projects so it reads as portfolio activity

## Validation
- `corepack pnpm exec eslint app/routes/index.tsx components/Home/GitHubRepos.tsx` passed
- `corepack pnpm build` passed
- `corepack pnpm typecheck` is blocked by existing `components/BioHeader/index.tsx` missing `../../app/routes/work/-work-data` after route generation; unrelated to this change